### PR TITLE
Update tracking.service.ts

### DIFF
--- a/backend/src/tracking/tracking/tracking.service.ts
+++ b/backend/src/tracking/tracking/tracking.service.ts
@@ -582,7 +582,7 @@ export class ParcelLabTrackingService {
         shopifyFulfillment.destination.name || order?.recipient_notification;
       tracking.recipient_notification =
         shopifyFulfillment.destination.name || order?.recipient_notification;
-      tracking.street = this.getStreet(shopifyFulfillment?.destination?.address1, shopifyFulfillment?.destination?.address1);
+      tracking.street = this.getStreet(shopifyFulfillment?.destination?.address1, shopifyFulfillment?.destination?.address2);
       tracking.zip_code = shopifyFulfillment.destination.zip;
 
       tracking.email = shopifyFulfillment?.email || order?.email;

--- a/backend/src/tracking/tracking/tracking.service.ts
+++ b/backend/src/tracking/tracking/tracking.service.ts
@@ -582,7 +582,7 @@ export class ParcelLabTrackingService {
         shopifyFulfillment.destination.name || order?.recipient_notification;
       tracking.recipient_notification =
         shopifyFulfillment.destination.name || order?.recipient_notification;
-      tracking.street = shopifyFulfillment.destination.address1;
+      tracking.street = this.getStreet(shopifyFulfillment?.destination?.address1, shopifyFulfillment?.destination?.address1);
       tracking.zip_code = shopifyFulfillment.destination.zip;
 
       tracking.email = shopifyFulfillment?.email || order?.email;
@@ -667,12 +667,7 @@ export class ParcelLabTrackingService {
       recipient: this.getName(shopifyOrder),
       recipient_notification: this.getName(shopifyOrder),
       statuslink: shopifyOrder?.order_status_url,
-      street: shopifyOrder?.shipping_address?.address1
-        + (
-          shopifyOrder?.shipping_address?.address2?.trim()
-            ? `\n${shopifyOrder?.shipping_address?.address2}`
-            : ''
-        ),
+      street: this.getStreet(shopifyOrder?.shipping_address?.address1, shopifyOrder?.shipping_address?.address2),
       warehouse: shopifyOrder?.location_id
         ? shopifyOrder.location_id.toString()
         : undefined,
@@ -1002,6 +997,16 @@ export class ParcelLabTrackingService {
       }
     }
     return undefined;
+  }
+  
+  protected getStreet(
+    address1: string | undefined,
+    address2: string | undefined
+  ): string | undefined {
+    return [address1, address2]
+      .map(addressLine => addressLine?.trim())
+      .filter(addressLine => !!addressline)
+      .join('\n');
   }
 
   protected transformCustomFields(

--- a/backend/src/tracking/tracking/tracking.service.ts
+++ b/backend/src/tracking/tracking/tracking.service.ts
@@ -667,7 +667,7 @@ export class ParcelLabTrackingService {
       recipient: this.getName(shopifyOrder),
       recipient_notification: this.getName(shopifyOrder),
       statuslink: shopifyOrder?.order_status_url,
-      street: `${shopifyOrder?.shipping_address?.address1}\n${shopifyOrder?.shipping_address?.address2}`,
+      street: shopifyOrder?.shipping_address?.address1 + (shopifyOrder?.shipping_address?.address2?.trim() ? `\n${shopifyOrder?.shipping_address?.address2}` : ''),
       warehouse: shopifyOrder?.location_id
         ? shopifyOrder.location_id.toString()
         : undefined,

--- a/backend/src/tracking/tracking/tracking.service.ts
+++ b/backend/src/tracking/tracking/tracking.service.ts
@@ -667,7 +667,12 @@ export class ParcelLabTrackingService {
       recipient: this.getName(shopifyOrder),
       recipient_notification: this.getName(shopifyOrder),
       statuslink: shopifyOrder?.order_status_url,
-      street: shopifyOrder?.shipping_address?.address1 + (shopifyOrder?.shipping_address?.address2?.trim() ? `\n${shopifyOrder?.shipping_address?.address2}` : ''),
+      street: shopifyOrder?.shipping_address?.address1
+        + (
+          shopifyOrder?.shipping_address?.address2?.trim()
+            ? `\n${shopifyOrder?.shipping_address?.address2}`
+            : ''
+        ),
       warehouse: shopifyOrder?.location_id
         ? shopifyOrder.location_id.toString()
         : undefined,

--- a/backend/src/tracking/tracking/tracking.service.ts
+++ b/backend/src/tracking/tracking/tracking.service.ts
@@ -667,7 +667,7 @@ export class ParcelLabTrackingService {
       recipient: this.getName(shopifyOrder),
       recipient_notification: this.getName(shopifyOrder),
       statuslink: shopifyOrder?.order_status_url,
-      street: shopifyOrder?.shipping_address?.address1,
+      street: `${shopifyOrder?.shipping_address?.address1}\n${shopifyOrder?.shipping_address?.address2}`,
       warehouse: shopifyOrder?.location_id
         ? shopifyOrder.location_id.toString()
         : undefined,


### PR DESCRIPTION
Bei der Übermittlung der Shopify-Orders an ParcelLab fehlt die Adresszeile 2.
Vielleicht ist nur diese Änderung nötig. Bin mir nicht sicher.